### PR TITLE
Integrate Sigmoid-Based Reward Calculation into get_rewards Function

### DIFF
--- a/bt_automata/validator/__init__.py
+++ b/bt_automata/validator/__init__.py
@@ -1,4 +1,3 @@
 from .reward_funcs import (
-    get_reward,
     get_rewards,
 )

--- a/bt_automata/validator/reward_funcs.py
+++ b/bt_automata/validator/reward_funcs.py
@@ -114,13 +114,10 @@ def get_rewards(
             return torch.FloatTensor([]).to(self.device)  # Or handle differently
 
         # Pull the process times from the synapse responses
-        process_times = [response.dendrite.process_time for uid, response in responses]
+        process_times_raw = [response.dendrite.process_time for uid, response in responses]
 
-        # Convert process times and result accuracies to tensors, if they aren't already
-        if not isinstance(process_times, torch.Tensor):
-            process_times = torch.tensor(process_times, dtype=torch.float32)
-        if not isinstance(result_accuracies, torch.Tensor):
-            result_accuracies = torch.tensor(result_accuracies, dtype=torch.float32)
+        # Convert process times to tensor
+        process_times = torch.tensor(process_times_raw, dtype=torch.float32)
 
         # Normalize process times inversely so that lower times are better
         normalized_process_times = (process_times - torch.min(process_times)) / (torch.max(process_times) - torch.min(process_times))
@@ -135,7 +132,7 @@ def get_rewards(
         accuracies_tensor = torch.tensor(accuracies, dtype=torch.float32)
 
         # Weight the accuracy and speed, multiplying by result_accuracy to handle 0 accuracy case mathematically
-        rewards = accuracies * sigmoid_process_times
+        rewards = accuracies_tensor * sigmoid_process_times
         if post_norm_or_max == "max":
             rn = rewards / torch.max(rewards)
         else:

--- a/bt_automata/validator/reward_funcs.py
+++ b/bt_automata/validator/reward_funcs.py
@@ -18,6 +18,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 import torch
+import torch.nn.functional as TF
 from typing import Any, List
 
 import numpy as np
@@ -30,19 +31,19 @@ from bt_automata.utils import rulesets
 from bt_automata.utils.misc import decompress_and_deserialize
 
 
-def get_reward(
+def get_accuracy(
     ground_truth_array: NDArray[Any],
     response: CAsynapse,
 ) -> float:
     """
-    Returns the reward value for the miner based on the comparison of the ground truth array and the response array.
+    Returns the accuracy value (0,1) for the miner based on the comparison of the ground truth array and the response array.
 
     Args:
     - ground_truth_array (NDArray[Any]): The ground truth array for the cellular automata.
     - response (CAsynapse): The response from the miner.
 
     Returns:
-    - float: The reward value for the miner.
+    - float: The (binary) accuracy value for the miner.
     """
 
     try:
@@ -56,11 +57,11 @@ def get_reward(
             bt.logging.debug("Response array is not a numpy array.")
             return 0.0
 
-        reward = 1.0 if np.array_equal(ground_truth_array, pred_array) else 0.0
+        accuracy = 1.0 if np.array_equal(ground_truth_array, pred_array) else 0.0
 
     except ValueError as e:
-        bt.logging.debug(f"Error in get_reward: {e}")
-        reward = 0.0
+        bt.logging.debug(f"Error in get_accuracy: {e}")
+        accuracy = 0.0
 
     ground_truth_str = np.array2string(ground_truth_array, threshold=10, edgeitems=2)
     pred_array_str = np.array2string(pred_array, threshold=10, edgeitems=2)
@@ -70,13 +71,26 @@ def get_reward(
         f"Comparison | \nGround Truth: \n{ground_truth_str} | \nResponse: \n{pred_array_str} | \nReward: {reward}"
     )
 
-    return reward
+    return accuracy
+
+
+def sigmoid(x, temperature=1.0, shift=0.0):
+    """
+    Returns the sigmoid transformation of the input tensor (vectorized)
+    Temperature controls the steepness of the sigmoid curve
+    Shift shifts the curve left or right along the x-axis.
+        Shift should be used to adjust the sigmoid curve to the range of the input values.
+    """
+    return 1 / (1 + torch.exp(-temperature * (x + shift)))
 
 
 def get_rewards(
     self,
     query_synapse: CAsynapse,
     responses: List[CAsynapse],
+    temperature = 10.0, #Steepness of the sigmoid curve
+    shift = -0.5, #Shifts sigmoid curve left or right along the x-axis
+    post_norm_or_max="max", #if anything but "max" tf.normalize is used, sum of the squares in the vector == 1.
 ) -> torch.FloatTensor:
     try:
         initial_state = decompress_and_deserialize(query_synapse.initial_state)
@@ -99,25 +113,40 @@ def get_rewards(
             bt.logging.debug("Simulation failed to produce a result.")
             return torch.FloatTensor([]).to(self.device)  # Or handle differently
 
+        # Pull the process times from the synapse responses
         process_times = [response.dendrite.process_time for uid, response in responses]
-        max_process_time, min_process_time = max(process_times), min(process_times)
-        rewards = np.zeros(256)
-        for uid, response in responses:
-            if response.array_data is None:
-                continue
-            result_accuracy = get_reward(gt_array, response)
-            # Linear normalization process time against the list of all miner process times
-            normalized_process_time = (
-                (response.dendrite.process_time - min_process_time)
-                / (max_process_time - min_process_time)
-                if max_process_time > min_process_time
-                else 0.0
-            )
-            # Include normalized process time in reward calculation
-            rewards[uid] = result_accuracy * 0.7 + 0.3 / (normalized_process_time + 1)
+
+        # Convert process times and result accuracies to tensors, if they aren't already
+        if not isinstance(process_times, torch.Tensor):
+            process_times = torch.tensor(process_times, dtype=torch.float32)
+        if not isinstance(result_accuracies, torch.Tensor):
+            result_accuracies = torch.tensor(result_accuracies, dtype=torch.float32)
+
+        # Normalize process times inversely so that lower times are better
+        normalized_process_times = (process_times - torch.min(process_times)) / (torch.max(process_times) - torch.min(process_times))
+        inverted_process_times = 1.0 - normalized_process_times  # Invert so higher times have lower scores
+        #breakpoint()
+
+        # Apply the sigmoid function to the inverted normalized process times
+        sigmoid_process_times = sigmoid(inverted_process_times, temperature, shift)
+
+        # Calculate accuracies for each response
+        accuracies = [get_accuracy(gt_array, response) for uid, response in responses]
+        accuracies_tensor = torch.tensor(accuracies, dtype=torch.float32)
+
+        # Weight the accuracy and speed, multiplying by result_accuracy to handle 0 accuracy case mathematically
+        rewards = accuracies * sigmoid_process_times
+        if post_norm_or_max == "max":
+            rn = rewards / torch.max(rewards)
+        else:
+            rn = TF.normalize(rewards, dim=0) # Norm such that the sum of the squares of all the elements in the vector will be 1.
+        #breakpoint()
+        return rn
+
 
     except Exception as e:
         bt.logging.debug(f"Error in get_rewards: {e}")
-        rewards = np.zeros(256)  # Decide on a fallback strategy
+        rewards = np.zeros(256)  # Fallback strategy: Log and return 0.
 
     return torch.FloatTensor(rewards).to(self.device)
+


### PR DESCRIPTION
This PR introduces chagnes to the get_rewards function  and supporting fnx within the reward_funcs.py module. By integrating a sigmoid-based reward calculation, we replace the previous linear reward scaling with a more nuanced approach that better reflects the relative performance of miners.

Key changes:
The addition of a vectorized sigmoid function that allows for adjustable steepness and midpoint shift through temperature and shift parameters, using the torch lib.

Modification of the get_rewards function to utilize the sigmoid function for calculating rewards based on the inverted normalized process times. (Faster is better). The rewards are also scaled such that the highest value is set to 1, providing a clear maximum reward and ensuring a consistent reward range across different sets of responses. Alternative scaling using the TF lib is available.

This update aims to provide a more merit-based reward distribution, taking into account both the accuracy and speed of responses in a non-linear fashion. The sigmoid function's flexibility allows for fine-tuning the reward curve to align with desired incentive structures.

Testing: We may need to adjust the shift parameter based on miner clock times to get the full "S" shape as desired. Assumes clock times are between .1 and .001 now. 