### PR TITLE
Update neuron.py for save_state warnings on miner

### DIFF
--- a/bt_automata/base/neuron.py
+++ b/bt_automata/base/neuron.py
@@ -121,7 +121,7 @@ class BaseNeuron(ABC):
             self.set_weights()
 
         # Always save state.
-        self.save_state()
+        #self.save_state()
 
     def check_registered(self):
         # --- Check for registration.


### PR DESCRIPTION
commented out call to save_state() which is not implemented