### PR TITLE
Enable Port Mapping for Miners Through Axon Configuration

### DIFF
--- a/bt_automata/base/miner.py
+++ b/bt_automata/base/miner.py
@@ -45,7 +45,7 @@ class BaseMinerNeuron(BaseNeuron):
             )
 
         # The axon handles request processing, allowing validators to send this miner requests.
-        self.axon = bt.axon(wallet=self.wallet, port=self.config.axon.port)
+        self.axon = bt.axon(wallet=self.wallet, port=self.config.axon.port, external_ip=self.config.axon.external_ip, external_port=self.config.axon.external_port)
 
         # Attach determiners which functions are called when servicing a request.
         bt.logging.info(f"Attaching forward function to miner axon.")

--- a/bt_automata/utils/config.py
+++ b/bt_automata/utils/config.py
@@ -75,6 +75,20 @@ def add_args(cls, parser):
     )
 
     parser.add_argument(
+        "--axon.external_port",
+        type=int,
+        help="The external port to serve the axon on.",
+        default=8091,
+    )
+
+    parser.add_argument(
+        "--axon.external_ip",
+        type=str,
+        help="The external ip to serve the axon on.",
+        default=""
+    )
+    
+    parser.add_argument(
         "--neuron.device",
         type=str,
         help="Device to run on.",


### PR DESCRIPTION
- Modified the Axon initialization to accept port, `external_ip`, and `external_port` parameters from the configuration settings.