### PR TITLE
Added 2D functionality.

### DIFF
--- a/bt_automata/utils/rulesets.py
+++ b/bt_automata/utils/rulesets.py
@@ -28,19 +28,47 @@ class ApplyRule(ABC):
     def rule_function(self, n, c, t):
         pass
 
-def get_initial_state(size, simple=False):
-    """
-    Get the initial state of the cellular automaton.
-    Can be either a simple or random initial state.
-    Random 1-D params:
-        init_random(size, k=2, n_randomized=None, empty_value=0, dtype=<class 'numpy.int32'>)
-    """
-    if simple:
-        return cpl.init_simple(size)
-    else:
-        return cpl.init_random(size, k=2, empty_value=0, dtype=np.int32)
+# def get_initial_state(size, simple=False):
+#     """
+#     Get the initial state of the cellular automaton.
+#     Can be either a simple or random initial state.
+#     Random 1-D params:
+#         init_random(size, k=2, n_randomized=None, empty_value=0, dtype=<class 'numpy.int32'>)
+#     """
+#     if simple:
+#         return cpl.init_simple(size)
+#     else:
+#         return cpl.init_random(size, k=2, empty_value=0, dtype=np.int32)
 
 
+class InitialConditions:
+    def __init__(self, size: int, percentage: float, simple: bool):
+        self.size = size
+        self.percentage = percentage
+        self.simple = False
+
+    def init_1d(self):
+        if self.simple:
+            return cpl.init_simple(size)
+        else:
+            return cpl.init_random(size, k=2, empty_value=0, dtype=np.int32)
+
+    def init_2d(self):
+        if self.simple:
+            cpl.init_simple2d(self.size, self.size)
+        else:
+            # Calculate the number of cells to be activated
+            num_cells = int(self.size * self.size * self.percentage)
+            # Create a flat array with the desired number of 1s and 0s
+            cells = np.array([1]*num_cells + [0]*(self.size^2 - num_cells))
+            # Randomly shuffle the array
+            np.random.shuffle(cells)
+            # Reshape the array to the size of the grid
+            initial_state = cells.reshape(1, rows, cols)
+            return initial_state
+
+
+#--------------1-D--------------#
 class Rule30(ApplyRule):
     """Class 3. Implementation of a one-dimensional cellular automaton rule,
     introduced by Stephen Wolfram, dubbed rule number 30 based on binary.
@@ -100,17 +128,112 @@ class Rule126(ApplyRule):
         return cpl.nks_rule(n, 126)
 
 
-# ----------------- 1D Cellular Automata Rules -----------------#
-# Create a mapping of rule names to classes
-rule_classes = {
+# ----------------- 2-D ------------------- #
+class GameOfLifeRule(ApplyRule):
+    """Implementation of Conway's Game of Life."""
+
+    def rule_function(self, n: NDArray, c: int, t: int) -> int:
+        # Count the number of live neighbors
+        live_neighbors = np.sum(n) - c
+
+        # Apply Conway's rules
+        if c == 1 and 2 <= live_neighbors <= 3:
+            return 1
+        elif c == 0 and live_neighbors == 3:
+            return 1
+        else:
+            return 0
+
+class HighLifeRule(ApplyRule):
+    """Implementation of Game of Life HighLife:
+    a variant of Conway's Game of Life that also gives birth to a cell if there are 6 neighbors.
+    """
+
+    def rule_function(self, n, c, t):
+        sum_n = np.sum(n)
+        return int(c and 2 <= sum_n <= 3 or sum_n == 6)
+
+
+class DayAndNightRule(ApplyRule):
+    """Implementation of Day & Night: a variant of Conway's Game of Life
+    that also gives birth to a cell if there are 3, 6, 7, or 8 neighbors."""
+
+    def rule_function(self, n, c, t):
+        sum_n = np.sum(n)
+        return sum_n in (3, 6, 7, 8) or c and sum_n in (4, 6, 7, 8)
+    
+
+class FredkinRule(ApplyRule):
+    """Implementation of Fredkin's is a cellular automaton rule where a cell is "born" if it has exactly one neighbor,
+    and a cell "survives" if it has exactly two neighbors. Otherwise, the cell dies or remains dead.
+    """
+
+    def rule_function(self, n, c, t):
+        sum_n = np.sum(n)
+        return sum_n == 1 or c and sum_n == 2
+
+
+class BriansBrainRule(ApplyRule):
+    """Implementation of Brian's Brain: a three-state simulation.
+    A cell is "born" if it was dead and has exactly two neighbors.
+    A live cell dies in the next generation, and a dead cell remains dead."""
+
+    def rule_function(self, n, c, t):
+        sum_n = np.sum(n)
+        if c == 0 and sum_n == 2:
+            return 1
+        elif c == 1:
+            return 2
+        elif c == 2:
+            return 0
+        else:
+            return 0  # or any other default value
+
+
+class SeedsRule(ApplyRule):
+    """Implementation of Seeds is a cellular automaton where a cell is "born" if it has exactly two neighbors,
+    and a cell "dies" otherwise."""
+
+    def rule_function(self, n, c, t):
+        sum_n = np.sum(n)
+        return int(sum_n == 2)
+    
+
+class LambdaRule(ApplyRule):
+    """Implementation of the Lambda rule for cellular automata. A cell is "born" if the number of its neighbors is greater than or equal to a parameter λ, and a cell "survives" if the number of its neighbors is less than or equal to λ."""
+
+    def __init__(self, lambda_value: int):
+        self.lambda_value = 0.37 #hard coded for now
+
+    def rule_function(self, n: NDArray, c: int, t: int) -> int:
+        sum_n = np.sum(n)
+        if c == 0 and sum_n >= self.lambda_value:
+            return 1
+        elif c == 1 and sum_n <= self.lambda_value:
+            return 1
+        else:
+            return 0
+
+# ----------------- Cellular Automata Rules -----------------#
+# Create mappings of rule names to classes
+rule_classes_1D = {
     "Rule30": Rule30,
     "Rule54": Rule54,
     "Rule62": Rule62,
     "Rule110": Rule110,
     "Rule124": Rule124,
-    "Rule126": Rule126,
+    "Rule126": Rule126
 }
+rule_classes_2D = {
+    "GameOfLifeRule":GameOfLifeRule,
+    "HighLifeRule":HighLifeRule,
+    "DayAndNightRule":DayAndNightRule,
+    "FredkinRule":FredkinRule,
+    "BriansBrainRule":BriansBrainRule,
+    "SeedsRule":SeedsRule,
+    "LambdaRule":LambdaRule
 
+}
 
 class Simulate1D:
     """Simulation for evolution of one-dimensional cellular automata.
@@ -151,4 +274,42 @@ class Simulate1D:
             raise RuntimeError("Error running simulation.") from e
 
 #        cpl.plot(ca)
+        return ca
+
+
+    
+class Simulate2D:
+    """Main simulation runner for 2D CA used in miner and validator routines"""
+
+    def __init__(
+        self,
+        ca: NDArray[np.float32],
+        timesteps: int,
+        rule_instance: ApplyRule,
+        r: int = 1,
+        neighbourhood_type: str = "Moore",
+    ):
+
+        if neighbourhood_type not in ["Moore", "von Neumann"]:
+            neighbourhood_type = "Moore"  # default to "Moore" if input is not valid
+
+        self.ca = ca
+        self.timesteps = timesteps
+        self.rule_instance = rule_instance
+        self.r = r
+        self.neighborhood_type = neighbourhood_type
+
+    def run(self) -> NDArray[Any]:
+        try:
+            ca = cpl.evolve2d(
+                cellular_automaton=self.ca,
+                timesteps=self.timesteps,
+                apply_rule=self.rule_instance.rule_function,
+                r=self.r,
+                neighbourhood=self.neighborhood_type,
+            )
+        except Exception as e:
+            raise RuntimeError(f"Error running simulation.") from e
+
+        #cpl.plot2d_animate(ca)
         return ca

--- a/bt_automata/validator/reward_funcs.py
+++ b/bt_automata/validator/reward_funcs.py
@@ -149,18 +149,25 @@ def get_rewards(
         timesteps = query_synapse.timesteps
         rule_name = query_synapse.rule_name
 
-        if rule_name not in rulesets.rule_classes:
+        if rule_name not in rulesets.rule_classes_1D and rule_name not in rulesets.rule_classes_2D:
             bt.logging.debug(f"Unknown rule name: {rule_name}")
             return torch.FloatTensor([]).to(self.device)  # Or handle differently
 
+
         bt.logging.debug(f"Calculating rewards for {len(responses)} responses.")
 
-        rule_func_class = rulesets.rule_classes[rule_name]
-        rule_func_obj = rule_func_class()
+        rule_func_class = None
+        if rule_name in rulesets.rule_classes_1D:
+            rule_func_class = rulesets.rule_classes_1D[rule_name]
+            gt_array = rulesets.Simulate1D(
+                initial_state, timesteps, rule_func_class(), r=1
+            ).run()
+        elif rule_name in rulesets.rule_classes_2D:
+            rule_func_class = rulesets.rule_classes_2D[rule_name]
+            gt_array = rulesets.Simulate2D(
+                initial_state, timesteps, rule_func_class(), r=1
+            ).run()
 
-        gt_array = rulesets.Simulate1D(
-            initial_state, timesteps, rule_func_obj, r=1
-        ).run()
         if gt_array is None:
             bt.logging.debug("Simulation failed to produce a result.")
             return torch.FloatTensor([]).to(self.device)  # Or handle differently

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -79,14 +79,23 @@ class Miner(BaseMinerNeuron):
 
             timesteps = synapse.timesteps
             rule_name = synapse.rule_name
-            rule_class = rulesets.rule_classes[rule_name]
-            rule_func_obj = rule_class()
 
+            if rule_name not in rulesets.rule_classes_1D and rule_name not in rulesets.rule_classes_2D:
+                bt.logging.debug(f"Unknown rule name: {rule_name}")
+                return synapse  # Or handle differently
+            
             # Run the simulation using the ruleset module.
             bt.logging.info(
                 f"Running simulation for {timesteps} timesteps with: {rule_name}."
             )
-            ca_sim = rulesets.Simulate1D(initial_state, timesteps, rule_func_obj, r=1)
+            rule_func_class = None
+            if rule_name in rulesets.rule_classes_1D:
+                rule_func_class = rulesets.rule_classes_1D[rule_name]
+                ca_sim = rulesets.Simulate1D(initial_state, timesteps, rule_func_class(), r=1)
+            elif rule_name in rulesets.rule_classes_2D:
+                rule_func_class = rulesets.rule_classes_2D[rule_name]
+                ca_sim = rulesets.Simulate2D(initial_state, timesteps, rule_func_class(), r=1)
+
             ca_done = ca_sim.run()
             if ca_done is None:
                 raise bt.logging.debug("Simulation failed to produce a result.")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -29,7 +29,8 @@ from bt_automata.base.validator import BaseValidatorNeuron
 
 # Internal modules
 from bt_automata.utils import rulesets
-from bt_automata.utils.rulesets import rule_classes
+from bt_automata.utils.rulesets import rule_classes_1D
+from bt_automata.utils.rulesets import rule_classes_2D
 from bt_automata.utils.misc import serialize_and_compress
 
 
@@ -63,18 +64,24 @@ class Validator(BaseValidatorNeuron):
         # size defines the dimensionn of the 1-D array. Between 100-1000
         size = random.randint(250, 500)
 
-        # Generate the initial state using the ruelsets module
-        initial_state_raw = rulesets.get_initial_state(size)
+                # Choose a random rule function. Limit to Class 3/4 rules in 1D. Covert it to a rule function using the rule_classes dictionary.
+        rule_name = random.choice(
+            ["Rule30", "Rule54", "Rule62", "Rule110", "Rule124", "Rule126", 
+             "GameofLifeRule"]
+        )
+
+        # Generate the initial state using the InitialConditions class
+        initial_conditions = rulesets.InitialConditions(size=size, percentage=0.33, simple=False)
+        if rule_name in rulesets.rule_classes_1D:
+            initial_state_raw = initial_conditions.init_1d()
+        elif rule_name in rulesets.rule_classes_2D:
+            initial_state_raw = initial_conditions.init_2d()
 
         # Choose a random number of time-steps, between 100 and 1000
         steps = random.randint(250, 500)
+        
 
-        # Choose a random rule function. Limit to Class 3/4 rules in 1D. Covert it to a rule function using the rule_classes dictionary.
-        rule_name = random.choice(
-            ["Rule30", "Rule54", "Rule62", "Rule110", "Rule124", "Rule126"]
-        )
-
-        if rule_name not in rule_classes:
+        if rule_name not in rule_classes_1D and rule_name not in rule_classes_2D:
             # Rule name not found. Sound the alarm
             raise bt.logging.debug(
                 f"Rule '{rule_name}' not found in rule_classes dictionary."


### PR DESCRIPTION
Description:
This PR introduces the ability to handle 2D cellular automata rulesets in addition to the existing 1D rulesets. The changes are designed to be backward compatible, ensuring that existing functionality with 1D rulesets remains unaffected.
Changes:
1. Updated Rulesets: Two separate dictionaries have been created for 1D and 2D rulesets in bt_automata/utils/rulesets.py. This allows for easy extension of the codebase with new rules and dimensions in the future. Rulesets for various 2D automata added. Initial conditions expanded and converted to a class.
3. Validator Class: The get_random_params method in the Validator class (neurons/validator.py) has been updated to generate initial states for both 1D and 2D cellular automata using the InitialConditions class.
4. Simulation Execution: The forward method in the Validator class and the get_rewards function in reward_funcs.py have been updated to select the appropriate simulation class (Simulate1D or Simulate2D) based on the rule's dimension.
5. Miner Class: The forward method in the Miner class (neurons/miner.py) has been updated to accommodate both 1D and 2D rulesets.